### PR TITLE
Update git urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake/cmake-d"]
 	path = cmake/cmake-d
-	url = git@github.com:Dadoum/cmake-d.git
+	url = https://github.com/Dadoum/cmake-d

--- a/LISEZMOI.md
+++ b/LISEZMOI.md
@@ -35,7 +35,7 @@ GTK+ et libimobiledevice.
 Clonez le projet et compilez le avec CMake:
 
 ```bash
-git clone git@github.com:Dadoum/Provision.git --recursive
+git clone https://github.com/Dadoum/Provision --recursive
 cd Provision
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To build *sideload_ipa*, you also need GTK+ and libimobiledevice development pac
 Clone the project and compile it with CMake:
 
 ```bash
-git clone git@github.com:Dadoum/Provision.git --recursive
+git clone https://github.com/Dadoum/Provision --recursive
 cd Provision
 mkdir build
 cd build


### PR DESCRIPTION
The command `git clone git@github.com:Dadoum/Provision.git --recursive` in the readme doesn't work when not signed in. Switches it and submodules to clone with https.