### PR TITLE
Support Advanced Data Protected iCloud accounts

### DIFF
--- a/lib/provision/adi.d
+++ b/lib/provision/adi.d
@@ -58,7 +58,7 @@ alias ADIGetIDMSRouting_t = extern(C) int function(ulong*, ulong);
     __gshared ADISetIDMSRouting_t pADISetIDMSRouting;
     __gshared ADIGetIDMSRouting_t pADIGetIDMSRouting;
 
-    string __clientInfo = "<iMac11,3> <Mac OS X;10.15.6;19G2021> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>";
+    string __clientInfo = "<iMac20,2> <Mac OS X;13.1;22C65> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>";
     public @property string clientInfo() shared {
         return __clientInfo;
     }


### PR DESCRIPTION
With the release of iOS/iPadOS 16.1, macOS 13.1, tvOS 16.1, and watchOS 9.2, I noticed the new Advanced Data Protection feature, allowing Apple IDs to be super secure with end-to-end encryption for more types of iCloud data.

However, enabling this feature means that you have to give up the past - if you aren't running an OS version greater than or equal to one of the above, you cannot sign into your Apple ID on that device. Naturally, this broke Provision due to spoofing an iMac11,3 on 10.15.7.

This pull request is a simple fix for that issue - I changed the model to iMac20,2 and the version to 13.1 - and all is working well with local tests.