### PR TITLE
Fix permissions for lib directory 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y ldc clang dub l
 WORKDIR /opt/
 COPY lib/ lib/
 COPY anisette_server/ anisette_server/
-COPY dub.sdl dub.selections.json .
+COPY dub.sdl dub.selections.json ./
 RUN dub build -c "static" --build-mode allAtOnce -b release --compiler=ldc2 :anisette-server
 
 # Base for run

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=builder /opt/bin/provision_anisette-server /opt/anisette_server
 
 # Setup rootless user which works with the volume mount
 RUN useradd -ms /bin/bash Chester \
+ && mkdir /opt/lib/ \
  && chown -R Chester /opt/ \
  && chmod -R +wx /opt/
 


### PR DESCRIPTION
Fixes #59 
/opt/lib directory was created when the lib_cache was mounted and hence was owned by root and not accessible to user Chester. This pull request creates lib directory before chown, so /opt/lib also belongs to user Chester.

Also fixes the docker build error when the destination directory for COPY doesn't end with /